### PR TITLE
Allow catching with Master Balls

### DIFF
--- a/modules/battle_strategies/catch.py
+++ b/modules/battle_strategies/catch.py
@@ -219,9 +219,9 @@ class CatchStrategy(DefaultBattleStrategy):
         opponent = battle_state.opponent.active_battler
         catch_rate_multiplier = 1
         match ball.index:
-            # Master Ball -- we never choose to throw this one, should be the player's choice
+            # Master Ball -- guarantee catch, prefer this if available
             case 1:
-                catch_rate_multiplier = -1
+                catch_rate_multiplier = 255
 
             # Ultra Ball
             case 2:

--- a/modules/items.py
+++ b/modules/items.py
@@ -428,6 +428,11 @@ class ItemBag:
     def number_of_balls_except_master_ball(self) -> int:
         return sum(slot.quantity for slot in self.poke_balls if slot.item.index != 1)
 
+    @property
+    def number_of_balls(self) -> int:
+        """Returns the total number of Poké Balls, including Master Balls."""
+        return sum(slot.quantity for slot in self.poke_balls)
+
     def to_dict(self) -> dict:
         return {
             "items": [s.to_dict() for s in self.items],

--- a/modules/modes/_asserts.py
+++ b/modules/modes/_asserts.py
@@ -201,12 +201,12 @@ def assert_player_has_poke_balls(check_in_saved_game: bool = False) -> None:
     if is_safari_map():
         if get_safari_balls_left() < 15:
             raise BotModeError(out_of_safari_balls_error)
-    elif check_in_saved_game and get_save_data().get_item_bag().number_of_balls_except_master_ball == 0:
-        if get_item_bag().number_of_balls_except_master_ball > 1:
+    elif check_in_saved_game and get_save_data().get_item_bag().number_of_balls == 0:
+        if get_item_bag().number_of_balls > 0:
             raise BotModeError(out_of_poke_balls_error + _error_message_addendum_if_assert_only_failed_in_saved_game)
         else:
             raise BotModeError(out_of_poke_balls_error)
-    elif get_item_bag().number_of_balls_except_master_ball == 0:
+    elif get_item_bag().number_of_balls == 0:
         raise BotModeError(out_of_poke_balls_error)
 
 


### PR DESCRIPTION
## Summary
- add a property to count all balls in the bag
- relax asserts to allow Master Ball only inventory
- let CatchStrategy actually pick the Master Ball

## Testing
- `python -m unittest discover -s tests` *(fails: ModuleNotFoundError: No module named 'rich', 'confz')*

------
https://chatgpt.com/codex/tasks/task_e_6849dbd94934832585229e3482cd67a2