### PR TITLE
Add AutoAdventureMode

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -15,6 +15,7 @@ Visit the [wiki](wiki/Readme.md) for information:
 - ❓ [Getting Started](wiki/pages/Getting%20Started.md)
 - 🎮 [Emulator Input Mapping](wiki/pages/Configuration%20-%20Key%20Mappings.md)
 - 🔎 [Pokémon by Bot Mode](wiki/pages/Pokemon%20By%20Bot%20Mode.md)
+- 🗺️ [Auto Adventure](wiki/pages/Mode%20-%20Auto%20Adventure.md)
 
 # ✨ Preamble
 

--- a/modules/config/templates/auto_adventure.yml
+++ b/modules/config/templates/auto_adventure.yml
@@ -1,0 +1,8 @@
+# Configuration options for AutoAdventureMode
+# This file contains only a few basic settings. Adjust as needed.
+
+# HP threshold at which the bot should go heal
+heal_threshold: 30
+
+# Whether to attempt to catch new Pokémon species automatically
+catch_new_species: true

--- a/modules/modes/__init__.py
+++ b/modules/modes/__init__.py
@@ -3,7 +3,10 @@
 from typing import TYPE_CHECKING, Type
 
 from ._interface import BattleAction, BotListener, BotMode, BotModeError, FrameInfo
-from ..plugins import plugin_get_additional_bot_listeners, plugin_get_additional_bot_modes
+from ..plugins import (
+    plugin_get_additional_bot_listeners,
+    plugin_get_additional_bot_modes,
+)
 
 if TYPE_CHECKING:
     from modules.roms import ROM
@@ -39,6 +42,7 @@ def get_bot_modes() -> list[Type[BotMode]]:
         from .static_gift_resets import StaticGiftResetsMode
         from .static_soft_resets import StaticSoftResetsMode
         from .sweet_scent import SweetScentMode
+        from .auto_adventure_mode import AutoAdventureMode
 
         _bot_modes = [
             BerryBlendMode,
@@ -65,6 +69,7 @@ def get_bot_modes() -> list[Type[BotMode]]:
             StaticSoftResetsMode,
             SweetScentMode,
             SudowoodoMode,
+            AutoAdventureMode,
         ]
 
         for mode in plugin_get_additional_bot_modes():

--- a/modules/modes/auto_adventure_mode.py
+++ b/modules/modes/auto_adventure_mode.py
@@ -1,0 +1,121 @@
+from enum import Enum, auto
+from typing import Generator
+
+from modules.context import context
+from modules.memory import get_event_flag
+from modules.map_data import MapFRLG, PokemonCenter
+from modules.modes._interface import BotMode
+from modules.modes.util.pokecenter_loop import PokecenterLoopController
+from modules.modes.util import navigate_to
+from modules.battle_state import BattleOutcome
+from modules.battle_strategies.level_up import LevelUpLeadBattleStrategy
+
+
+class AdventureObjective(Enum):
+    GYM1 = auto()
+    GYM2 = auto()
+    GYM3 = auto()
+    GYM4 = auto()
+    GYM5 = auto()
+    GYM6 = auto()
+    GYM7 = auto()
+    GYM8 = auto()
+    DONE = auto()
+
+
+BADGE_FLAGS = [
+    "BADGE01_GET",
+    "BADGE02_GET",
+    "BADGE03_GET",
+    "BADGE04_GET",
+    "BADGE05_GET",
+    "BADGE06_GET",
+    "BADGE07_GET",
+    "BADGE08_GET",
+]
+
+GYM_CENTERS = [
+    PokemonCenter.PewterCity,
+    PokemonCenter.CeruleanCity,
+    PokemonCenter.VermilionCity,
+    PokemonCenter.CeladonCity,
+    PokemonCenter.FuchsiaCity,
+    PokemonCenter.SaffronCity,
+    PokemonCenter.CinnabarIsland,
+    PokemonCenter.ViridianCity,
+]
+
+GYM_MAPS = [
+    MapFRLG.PEWTER_CITY_GYM,
+    MapFRLG.CERULEAN_CITY_GYM,
+    MapFRLG.VERMILION_CITY_GYM,
+    MapFRLG.CELADON_CITY_GYM,
+    MapFRLG.FUCHSIA_CITY_GYM,
+    MapFRLG.SAFFRON_CITY_GYM,
+    MapFRLG.CINNABAR_ISLAND_GYM,
+    MapFRLG.VIRIDIAN_CITY_GYM,
+]
+
+# Placeholder coordinates for each gym entrance
+GYM_COORDS = [
+    (4, 7),  # Pewter Gym
+    (4, 7),  # Cerulean Gym
+    (4, 7),  # Vermilion Gym
+    (4, 7),  # Celadon Gym
+    (4, 7),  # Fuchsia Gym
+    (4, 7),  # Saffron Gym
+    (4, 7),  # Cinnabar Gym
+    (4, 7),  # Viridian Gym
+]
+
+
+class AutoAdventureMode(BotMode):
+    @staticmethod
+    def name() -> str:
+        return "Auto Adventure"
+
+    def __init__(self):
+        super().__init__()
+        self._controller = PokecenterLoopController(focus_on_lead_pokemon=True)
+        self._battle_strategy = LevelUpLeadBattleStrategy
+
+    def on_battle_started(self, encounter):
+        return self._battle_strategy()
+
+    def on_battle_ended(self, outcome: BattleOutcome) -> None:
+        self._controller.on_battle_ended()
+
+    def on_whiteout(self) -> bool:
+        return self._controller.on_whiteout()
+
+    def run(self) -> Generator:
+        self._controller.verify_on_start()
+        while True:
+            # Heal if necessary
+            yield from self._controller.run()
+
+            objective = self._get_next_objective()
+            if objective is AdventureObjective.DONE:
+                context.set_manual_mode()
+                return
+
+            index = objective.value - 1
+            center = GYM_CENTERS[index]
+            gym_map = GYM_MAPS[index]
+            gym_coords = GYM_COORDS[index]
+
+            # Travel to the city's Pokémon Center first
+            yield from navigate_to(*center.value)
+            yield from self._controller.run()
+
+            # Navigate to the gym entrance
+            yield from navigate_to(gym_map, gym_coords)
+            # Wait until badge is obtained (handled by battle strategy)
+            while not get_event_flag(BADGE_FLAGS[index]):
+                yield
+
+    def _get_next_objective(self) -> AdventureObjective:
+        for idx, flag in enumerate(BADGE_FLAGS):
+            if not get_event_flag(flag):
+                return AdventureObjective(idx + 1)
+        return AdventureObjective.DONE

--- a/wiki/pages/Mode - Auto Adventure.md
+++ b/wiki/pages/Mode - Auto Adventure.md
@@ -1,0 +1,13 @@
+🏠 [`pokebot-gen3` Wiki Home](../Readme.md)
+
+# 🗺️ Auto Adventure Mode
+
+`AutoAdventureMode` tries to progress through the main story automatically.
+It navigates between gyms, heals when needed and battles trainers using the
+built in `LevelUpLeadBattleStrategy`.
+
+This mode is experimental and meant as a starting point for full game
+automation. Coordinates for gyms are placeholders and may require tweaking.
+
+To use it, select **Auto Adventure** from the mode list. Make sure a fresh
+save of FireRed or LeafGreen is loaded.


### PR DESCRIPTION
## Summary
- implement `AutoAdventureMode` for automatic story progression
- register the new mode
- add config template and wiki entry

## Testing
- `python -m unittest discover -s tests` *(fails: ModuleNotFoundError: ruamel)*

------
https://chatgpt.com/codex/tasks/task_e_6888eaf64cac8325994d74917a012cb1