### PR TITLE
Adjust level threshold to 10

### DIFF
--- a/modules/modes/auto_adventure_mode.py
+++ b/modules/modes/auto_adventure_mode.py
@@ -24,6 +24,10 @@ from modules.battle_strategies.level_up import LevelUpLeadBattleStrategy
 from modules.battle_strategies.level_balancing import LevelBalancingBattleStrategy
 from modules.battle_strategies.catch import CatchStrategy
 
+# Difference in levels between the party and local encounters after which the
+# bot should advance to the next area.
+OVERLEVELED_LEVEL_DIFF = 10
+
 
 class AdventureObjective(Enum):
     GYM1 = auto()
@@ -226,7 +230,10 @@ class AutoAdventureMode(BotMode):
             area_max = self._area_max_level()
             if party_levels:
                 avg_level = sum(party_levels) / len(party_levels)
-                overleveled = avg_level > area_max + 5 or all(l > area_max + 5 for l in party_levels)
+                overleveled = (
+                    avg_level > area_max + OVERLEVELED_LEVEL_DIFF
+                    or all(l > area_max + OVERLEVELED_LEVEL_DIFF for l in party_levels)
+                )
                 if overleveled:
                     context.message = (
                         f"Equipo sobreleveleado (promedio lvl {avg_level:.1f}) para zona, avanzando al siguiente centro"

--- a/modules/modes/smart_adventure_mode.py
+++ b/modules/modes/smart_adventure_mode.py
@@ -16,6 +16,10 @@ from modules.pokemon_party import get_party
 from modules.battle_state import BattleOutcome
 from modules.battle_strategies.level_up import LevelUpLeadBattleStrategy
 
+# Difference in levels between the party and local encounters after which the
+# bot should advance to the next area.
+OVERLEVELED_LEVEL_DIFF = 10
+
 
 class AdventureObjective(Enum):
     GYM1 = auto()
@@ -165,7 +169,9 @@ class SmartAdventureMode(BotMode):
 
             area_max_level = self._area_max_level()
             party_levels = [p.level for p in get_party() if not p.is_egg]
-            if party_levels and all(l > area_max_level + 5 for l in party_levels):
+            if party_levels and all(
+                l > area_max_level + OVERLEVELED_LEVEL_DIFF for l in party_levels
+            ):
                 context.message = f"Equipo sobreleveleado (lvl {max(party_levels)}) para zona '{current_area.map_name}'"
                 print(context.message)
                 index = objective.value - 1


### PR DESCRIPTION
## Summary
- add `OVERLEVELED_LEVEL_DIFF` constant in auto and smart adventure modes
- advance to new area when party is more than 10 levels above local Pokémon

## Testing
- `pip install -r <(python - <<'PY'
from requirements import required_modules
print('\n'.join(required_modules))
PY
)`
- `pytest -q` *(fails: PortAudio library not found)*

------
https://chatgpt.com/codex/tasks/task_e_688947948f908325bf2be1201fef2cb5